### PR TITLE
Emulate MacOS-style window chrome on all supported platforms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "owls",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="app" class="m-6 rounded-lg bg-white overflow-hidden shadow-window">
     <router-view />
   </div>
 </template>

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -1,5 +1,10 @@
 @tailwind base;
 
+html, body {
+    width: 760px;
+    height: 560px;
+}
+
 @tailwind components;
 
 @tailwind utilities;

--- a/src/background.js
+++ b/src/background.js
@@ -20,10 +20,12 @@ protocol.registerSchemesAsPrivileged([{scheme: 'app', privileges: { secure: true
 function createWindow () {
   // Create the browser window.
   win = new BrowserWindow({ 
-    width: 800, 
-    height: 600, 
+    width: 840, 
+    height: 640, 
     frame: false,
     resizable: false,
+    transparent: true,
+    hasShadow: false,
     webPreferences: {
       nodeIntegration: true
     } 

--- a/src/services/system.js
+++ b/src/services/system.js
@@ -54,6 +54,10 @@ export function saveHostEntries(projects) {
   })
 }
 
+export function getPlatform() {
+  return process.platform
+}
+
 export function getPlatformHuman() {
   switch(process.platform) {
     case 'darwin':
@@ -85,6 +89,7 @@ export default {
   getHostsPath,
   getHostsEntries,
   saveHostEntries,
+  getPlatform,
   getPlatformHuman,
   getPermissionTip,
   getCurrentUser

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ module.exports = {
     extend: {
       colors: {
         'semi-75': 'rgba(0, 0, 0, 0.75)',
+      },
+      boxShadow: {
+        window: '0 0 30px -10px rgba(0, 0, 0, 0.75)'
       }
     },
   },


### PR DESCRIPTION
Related: #9 

💁 This PR addresses inconsistency in window chrome across supported platforms. 

Before this patch, MacOS rendered the window with rounded corners and a drop shadow. On Windows, we got pointed corners and a smaller shadow. On Linux, who knows.

This patch tries to achieve similar look and feel across all platforms. We do this by making the actual `BrowserWindow` larger than we need. Then, we use the extra space to create margin where we draw our own drop shadow. 

This needs to be tested side-by-side on supported platforms, then we can merge.